### PR TITLE
feat(security): expose JWKS publicly and externalize JWT key loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+.kotlin
+
+### Secrets ###
+secrets/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,15 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# =========================
+# JWT / RSA keys (SECURITY)
+# =========================
+src/main/resources/keys/private.pem
+src/main/resources/keys/public.pem

--- a/src/main/java/org/example/crm/adapter/in/web/controller/JwksController.java
+++ b/src/main/java/org/example/crm/adapter/in/web/controller/JwksController.java
@@ -1,0 +1,32 @@
+package org.example.crm.adapter.in.web.controller;
+
+import org.example.crm.adapter.in.web.security.JwtService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * Public JWKS endpoint.
+ *
+ * Needed for:
+ * - external clients/services to validate your JWT signature using public key
+ *
+ * NOTE:
+ * - pure inbound web adapter
+ * - delegates to JwtService (technical security service)
+ */
+@RestController
+public class JwksController {
+
+    private final JwtService jwtService;
+
+    public JwksController(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @GetMapping("/.well-known/jwks.json")
+    public Map<String, Object> jwks() {
+        return jwtService.getJwks();
+    }
+}

--- a/src/main/java/org/example/crm/adapter/in/web/security/JwtService.java
+++ b/src/main/java/org/example/crm/adapter/in/web/security/JwtService.java
@@ -12,7 +12,9 @@ import org.example.crm.domain.model.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -60,15 +62,12 @@ public class JwtService {
         this.issuer = issuer;
         this.audience = audience;
 
-        try (InputStream privateStream = resource(keysPath + "/private.pem");
-             InputStream publicStream  = resource(keysPath + "/public.pem")) {
-
-            String privatePem = new String(privateStream.readAllBytes())
+            String privatePem = Files.readString(Path.of(keysPath, "private.pem"), StandardCharsets.UTF_8)
                     .replaceAll("-----\\w+ RSA PRIVATE KEY-----", "")
                     .replaceAll("-----\\w+ PRIVATE KEY-----", "")
                     .replaceAll("\\s", "");
 
-            String publicPem = new String(publicStream.readAllBytes())
+            String publicPem = Files.readString(Path.of(keysPath, "public.pem"), StandardCharsets.UTF_8)
                     .replaceAll("-----\\w+ PUBLIC KEY-----", "")
                     .replaceAll("\\s", "");
 
@@ -79,14 +78,8 @@ public class JwtService {
 
             this.privateKey = (RSAPrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(privateBytes));
             this.publicKey  = (RSAPublicKey)  kf.generatePublic(new X509EncodedKeySpec(publicBytes));
-        }
     }
 
-    private static InputStream resource(String path) {
-        InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
-        if (is == null) throw new IllegalStateException("RSA key file not found in classpath: " + path);
-        return is;
-    }
 
     /**
      * Creates a short-lived access token (RS256).

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/crm}
+    username: ${SPRING_DATASOURCE_USERNAME:crm}
+    password: ${SPRING_DATASOURCE_PASSWORD:crm_pass}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: none
+  flyway:
+    enabled: true
+    locations:
+      - classpath:db/migration
+
+server:
+  port: 8080
+
+jwt:
+  issuer: ${JWT_ISSUER:http://localhost:8080}
+  audience: ${JWT_AUDIENCE:crm-frontend}
+  keys:
+    path: ${JWT_KEYS_PATH:keys}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,mappings


### PR DESCRIPTION
Expose /.well-known/jwks.json, keep actuator surface minimal, and load JWT keys from an external mounted path instead of bundling them into the application artifact.

Refs #8