### PR TITLE
feat(frontend): wire frontend to backend via shared axios client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3.9-eclipse-temurin-21 AS build
+WORKDIR /build
+COPY pom.xml .
+COPY src ./src
+
+RUN mvn -q -DskipTests package \
+ && ls -la target \
+ && cp target/*.jar /build/app.jar
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /build/app.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
Use VITE_API_URL, centralize API calls in a shared axios client, and load organizations from the backend instead of mocks.

Refs #17